### PR TITLE
Fix #5: Add password-based admin authentication to dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ TRIGGER_MENTION=@claude-swarm
 # Use a GitHub-associated name/email so platforms recognise the commit author.
 GIT_AUTHOR_NAME=Your Name
 GIT_AUTHOR_EMAIL=your-email@example.com
+# Dashboard admin credentials
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=your-strong-password-here

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -32,10 +32,11 @@ export function App() {
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [plannerOpen, setPlannerOpen] = useState(false)
   const { selectedWorkspaceId } = useWorkspaceContext()
-  const { error: metricsError } = useMetrics(selectedWorkspaceId)
-  const { data: agentsData } = useAgents(selectedWorkspaceId)
-  const { data: issuesData } = useIssues(selectedWorkspaceId)
-  const { data: prsData } = usePRs(selectedWorkspaceId)
+  const queryEnabled = isAuthenticated && !isChecking
+  const { error: metricsError } = useMetrics(selectedWorkspaceId, { enabled: queryEnabled })
+  const { data: agentsData } = useAgents(selectedWorkspaceId, { enabled: queryEnabled })
+  const { data: issuesData } = useIssues(selectedWorkspaceId, { enabled: queryEnabled })
+  const { data: prsData } = usePRs(selectedWorkspaceId, { enabled: queryEnabled })
 
   if (isChecking) {
     return <div className="min-h-screen bg-[var(--bg)]" />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,8 @@ import { useAgents } from './hooks/useAgents'
 import { useIssues } from './hooks/useIssues'
 import { usePRs } from './hooks/usePRs'
 import { useWorkspaceContext } from './context/WorkspaceContext'
+import { useAuth } from './context/AuthContext'
+import { LoginPage } from './components/auth/LoginPage'
 
 function ErrorBanner({ error }) {
   if (!error) return null
@@ -24,16 +26,24 @@ function ErrorBanner({ error }) {
 }
 
 export function App() {
+  const { isAuthenticated, isChecking } = useAuth()
   const [activeTab, setActiveTab] = useState('agents')
   const [addWorkspaceOpen, setAddWorkspaceOpen] = useState(false)
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [plannerOpen, setPlannerOpen] = useState(false)
   const { selectedWorkspaceId } = useWorkspaceContext()
-
   const { error: metricsError } = useMetrics(selectedWorkspaceId)
   const { data: agentsData } = useAgents(selectedWorkspaceId)
   const { data: issuesData } = useIssues(selectedWorkspaceId)
   const { data: prsData } = usePRs(selectedWorkspaceId)
+
+  if (isChecking) {
+    return <div className="min-h-screen bg-[var(--bg)]" />
+  }
+
+  if (!isAuthenticated) {
+    return <LoginPage />
+  }
 
   const counts = {
     agents: agentsData?.total ?? 0,

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -13,8 +13,10 @@ async function apiFetch(path, options = {}) {
   })
 
   if (res.status === 401) {
-    localStorage.removeItem(TOKEN_KEY)
-    window.dispatchEvent(new CustomEvent('swarm:unauthorized'))
+    if (token) {
+      localStorage.removeItem(TOKEN_KEY)
+      window.dispatchEvent(new CustomEvent('swarm:unauthorized'))
+    }
     throw new Error('Unauthorized')
   }
 

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,17 +1,39 @@
+export const TOKEN_KEY = 'swarm_auth_token'
+
 const BASE = ''
 
 async function apiFetch(path, options = {}) {
   const { headers: customHeaders, ...rest } = options
+  const token = localStorage.getItem(TOKEN_KEY)
+  const authHeaders = token ? { 'Authorization': `Bearer ${token}` } : {}
+
   const res = await fetch(`${BASE}${path}`, {
-    headers: { 'Content-Type': 'application/json', ...customHeaders },
+    headers: { 'Content-Type': 'application/json', ...authHeaders, ...customHeaders },
     ...rest,
   })
+
+  if (res.status === 401) {
+    localStorage.removeItem(TOKEN_KEY)
+    window.dispatchEvent(new CustomEvent('swarm:unauthorized'))
+    throw new Error('Unauthorized')
+  }
+
   if (!res.ok) {
     const err = await res.json().catch(() => ({ error: res.statusText }))
     throw new Error(err.error || `HTTP ${res.status}`)
   }
   return res.json()
 }
+
+// Auth
+export const login = (username, password) =>
+  apiFetch('/api/auth/login', { method: 'POST', body: JSON.stringify({ username, password }) })
+
+export const logout = () =>
+  apiFetch('/api/auth/logout', { method: 'POST' })
+
+export const checkAuth = () =>
+  apiFetch('/api/auth/check')
 
 // Metrics
 export const getMetrics = (wsId) =>

--- a/frontend/src/components/auth/LoginPage.jsx
+++ b/frontend/src/components/auth/LoginPage.jsx
@@ -1,0 +1,80 @@
+import { useState } from 'react'
+import { useAuth } from '../../context/AuthContext'
+
+export function LoginPage() {
+  const { login } = useAuth()
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState(null)
+  const [loading, setLoading] = useState(false)
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+    try {
+      await login(username, password)
+    } catch (err) {
+      setError(err.message === 'Unauthorized' ? 'Invalid username or password' : err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-[var(--bg)]">
+      <div className="w-full max-w-sm">
+        <div className="mb-8 text-center">
+          <div className="flex items-center justify-center gap-2.5 mb-2">
+            <div className="w-2 h-2 rounded-full bg-[var(--accent)] shadow-[0_0_8px_var(--accent)]" />
+            <h1 className="text-[18px] font-semibold tracking-tight">Claude Code Swarm</h1>
+          </div>
+          <p className="text-[12px] text-[var(--text-muted)]">Sign in to access the dashboard</p>
+        </div>
+
+        <form
+          onSubmit={handleSubmit}
+          className="bg-[var(--surface)] border border-[var(--border)] rounded-xl p-6 flex flex-col gap-4"
+        >
+          {error && (
+            <div className="text-[11px] text-[var(--red)] bg-[var(--red-dim)] border border-[rgba(248,113,113,0.15)] rounded-md px-3 py-2 font-mono">
+              {error}
+            </div>
+          )}
+
+          <div className="flex flex-col gap-1.5">
+            <label className="text-[11px] text-[var(--text-muted)] font-medium">Username</label>
+            <input
+              type="text"
+              autoComplete="username"
+              value={username}
+              onChange={e => setUsername(e.target.value)}
+              className="bg-[var(--bg)] border border-[var(--border)] rounded-md px-3 py-2 text-[13px] text-[var(--text)] outline-none focus:border-[var(--accent)] transition-colors"
+              required
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label className="text-[11px] text-[var(--text-muted)] font-medium">Password</label>
+            <input
+              type="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              className="bg-[var(--bg)] border border-[var(--border)] rounded-md px-3 py-2 text-[13px] text-[var(--text)] outline-none focus:border-[var(--accent)] transition-colors"
+              required
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="mt-1 px-4 py-2 text-[12px] font-semibold bg-[var(--accent)] text-white rounded-md hover:brightness-110 disabled:opacity-50 disabled:cursor-not-allowed transition-all shadow-[0_0_16px_rgba(139,92,246,0.2)]"
+          >
+            {loading ? 'Signing in\u2026' : 'Sign in'}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/layout/Header.jsx
+++ b/frontend/src/components/layout/Header.jsx
@@ -1,8 +1,9 @@
-import { Settings, Plus, Check, AlertTriangle, RefreshCw } from 'lucide-react'
+import { Settings, Plus, Check, AlertTriangle, RefreshCw, LogOut } from 'lucide-react'
 import { WorkspaceSwitcher } from './WorkspaceSwitcher'
 import { useMetrics } from '../../hooks/useMetrics'
 import { useGitSync } from '../../hooks/useGitSync'
 import { useWorkspaceContext } from '../../context/WorkspaceContext'
+import { useAuth } from '../../context/AuthContext'
 import { formatDistanceToNow } from 'date-fns'
 
 function SyncIndicator({ wsId }) {
@@ -38,6 +39,7 @@ function SyncIndicator({ wsId }) {
 
 export function Header({ onAddWorkspace, onOpenSettings, onOpenPlanner }) {
   const { selectedWorkspaceId } = useWorkspaceContext()
+  const { logout } = useAuth()
   const { dataUpdatedAt } = useMetrics(selectedWorkspaceId)
 
   const lastUpdated = dataUpdatedAt
@@ -82,6 +84,13 @@ export function Header({ onAddWorkspace, onOpenSettings, onOpenPlanner }) {
             <Settings size={14} />
           </button>
         )}
+        <button
+          onClick={logout}
+          className="p-1.5 rounded-md text-[var(--text-muted)] hover:text-[var(--red)] hover:bg-[var(--surface-hover)] transition-colors"
+          title="Sign out"
+        >
+          <LogOut size={14} />
+        </button>
       </div>
     </header>
   )

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,0 +1,52 @@
+import { createContext, useContext, useState, useEffect, useCallback } from 'react'
+import { TOKEN_KEY, login as apiLogin, logout as apiLogout, checkAuth } from '../api/client'
+
+const AuthContext = createContext(null)
+
+export function AuthProvider({ children }) {
+  const [token, setToken] = useState(() => localStorage.getItem(TOKEN_KEY))
+  const [isChecking, setIsChecking] = useState(() => !!localStorage.getItem(TOKEN_KEY))
+
+  // On mount: verify existing token against server
+  useEffect(() => {
+    if (!token) {
+      setIsChecking(false)
+      return
+    }
+    checkAuth()
+      .then(() => setIsChecking(false))
+      .catch(() => setIsChecking(false)) // 401 fires swarm:unauthorized below
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Listen for 401 responses from apiFetch
+  useEffect(() => {
+    const handler = () => setToken(null)
+    window.addEventListener('swarm:unauthorized', handler)
+    return () => window.removeEventListener('swarm:unauthorized', handler)
+  }, [])
+
+  const login = useCallback(async (username, password) => {
+    const data = await apiLogin(username, password)
+    localStorage.setItem(TOKEN_KEY, data.token)
+    setToken(data.token)
+    return data
+  }, [])
+
+  const logout = useCallback(async () => {
+    try { await apiLogout() } catch {}
+    localStorage.removeItem(TOKEN_KEY)
+    setToken(null)
+  }, [])
+
+  return (
+    <AuthContext.Provider value={{ token, isAuthenticated: !!token, isChecking, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider')
+  return ctx
+}

--- a/frontend/src/hooks/useAgents.js
+++ b/frontend/src/hooks/useAgents.js
@@ -2,10 +2,11 @@ import { useRef } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { getAgents, getAgentLogs } from '../api/client'
 
-export function useAgents(wsId, { limit = 20, offset = 0 } = {}) {
+export function useAgents(wsId, { limit = 20, offset = 0, enabled = true } = {}) {
   return useQuery({
     queryKey: ['agents', wsId, limit, offset],
     queryFn: () => getAgents(wsId, limit, offset),
+    enabled,
     refetchInterval: 3000,
     staleTime: 0,
   })

--- a/frontend/src/hooks/useIssues.js
+++ b/frontend/src/hooks/useIssues.js
@@ -1,10 +1,11 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { getIssues, updateIssueStatus } from '../api/client'
 
-export function useIssues(wsId) {
+export function useIssues(wsId, { enabled = true } = {}) {
   return useQuery({
     queryKey: ['issues', wsId],
     queryFn: () => getIssues(wsId),
+    enabled,
     refetchInterval: 5000,
     staleTime: 0,
   })

--- a/frontend/src/hooks/useMetrics.js
+++ b/frontend/src/hooks/useMetrics.js
@@ -1,10 +1,11 @@
 import { useQuery } from '@tanstack/react-query'
 import { getMetrics } from '../api/client'
 
-export function useMetrics(wsId) {
+export function useMetrics(wsId, { enabled = true } = {}) {
   return useQuery({
     queryKey: ['metrics', wsId],
     queryFn: () => getMetrics(wsId),
+    enabled,
     refetchInterval: 3000,
     staleTime: 0,
   })

--- a/frontend/src/hooks/usePRs.js
+++ b/frontend/src/hooks/usePRs.js
@@ -1,10 +1,11 @@
 import { useQuery } from '@tanstack/react-query'
 import { getPRs } from '../api/client'
 
-export function usePRs(wsId) {
+export function usePRs(wsId, { enabled = true } = {}) {
   return useQuery({
     queryKey: ['prs', wsId],
     queryFn: () => getPRs(wsId),
+    enabled,
     refetchInterval: 5000,
     staleTime: 0,
   })

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { WorkspaceProvider } from './context/WorkspaceContext'
+import { AuthProvider } from './context/AuthContext'
 import { App } from './App'
 import './index.css'
 
@@ -17,9 +18,11 @@ const queryClient = new QueryClient({
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <WorkspaceProvider>
-        <App />
-      </WorkspaceProvider>
+      <AuthProvider>
+        <WorkspaceProvider>
+          <App />
+        </WorkspaceProvider>
+      </AuthProvider>
     </QueryClientProvider>
   </StrictMode>
 )

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -51,6 +51,10 @@ SKILLS_ENABLED = os.environ.get("SKILLS_ENABLED", "true").lower() in ("true", "1
 # === Dashboard ===
 DASHBOARD_PORT = int(os.environ.get("DASHBOARD_PORT", "8420"))
 
+# === Dashboard Admin Auth ===
+ADMIN_USERNAME = os.environ.get("ADMIN_USERNAME", "admin")
+ADMIN_PASSWORD = os.environ.get("ADMIN_PASSWORD", "")
+
 # === Workspaces ===
 WORKSPACES_DIR = Path(os.environ.get("WORKSPACES_DIR", "/root/workspaces"))
 
@@ -74,6 +78,8 @@ def validate_environment() -> list[str]:
         errors.append("CLAUDE_CODE_OAUTH_TOKEN is not set")
     if not GH_TOKEN:
         errors.append("GH_TOKEN is not set")
+    if not ADMIN_PASSWORD:
+        errors.append("ADMIN_PASSWORD is not set — the dashboard is unprotected")
 
     # Check claude CLI
     if not shutil.which("claude"):
@@ -121,6 +127,8 @@ def print_config():
     print(f"  MAX_RATE_RESUMES:      {MAX_RATE_LIMIT_RESUMES}")
     print(f"  SKILLS_ENABLED:        {SKILLS_ENABLED}")
     print(f"  DASHBOARD_PORT:        {DASHBOARD_PORT}")
+    print(f"  ADMIN_USERNAME:        {ADMIN_USERNAME}")
+    print(f"  ADMIN_PASSWORD:        {'(set)' if ADMIN_PASSWORD else '(NOT SET — unprotected!)'}")
     print(f"  GIT_AUTHOR_NAME:       {GIT_AUTHOR_NAME or '(not set — agent default)'}")
     print(f"  GIT_AUTHOR_EMAIL:      {GIT_AUTHOR_EMAIL or '(not set — agent default)'}")
     token_preview = CLAUDE_CODE_OAUTH_TOKEN[:12] + "..." if CLAUDE_CODE_OAUTH_TOKEN else "(not set)"

--- a/orchestrator/dashboard.py
+++ b/orchestrator/dashboard.py
@@ -4,12 +4,14 @@ import asyncio
 import json
 import logging
 import os
+import secrets
 import signal
 import time
 import uuid
+from datetime import datetime, timedelta
 from pathlib import Path
 
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
@@ -18,8 +20,31 @@ from orchestrator import db
 from orchestrator import planner
 from orchestrator import worktree
 from orchestrator import workspace_manager as wm
+from orchestrator.config import ADMIN_USERNAME, ADMIN_PASSWORD
 
 app = FastAPI(title="Claude Code Swarm Dashboard")
+
+SESSION_DURATION_DAYS = 30
+
+
+@app.middleware("http")
+async def auth_middleware(request: Request, call_next):
+    path = request.url.path
+    # Allow: login endpoint, static assets, and SPA HTML (non-API paths)
+    if path in ("/api/auth/login",) or not path.startswith("/api/"):
+        return await call_next(request)
+
+    # All other /api/* routes require a valid session token
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return JSONResponse({"detail": "Not authenticated"}, status_code=401)
+
+    token = auth_header[7:]  # strip "Bearer "
+    session = db.get_session(token)
+    if session is None:
+        return JSONResponse({"detail": "Invalid or expired session"}, status_code=401)
+
+    return await call_next(request)
 
 STATIC_DIR = Path(__file__).parent / "static"
 
@@ -34,6 +59,11 @@ def set_agent_pool(pool):
 
 
 # === Pydantic Models ===
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
 
 class CreateWorkspaceRequest(BaseModel):
     repo_url: str
@@ -60,6 +90,40 @@ async def index():
     if not index.exists():
         raise HTTPException(status_code=404, detail="Frontend not built")
     return FileResponse(str(index))
+
+
+# === Auth Endpoints ===
+
+@app.post("/api/auth/login")
+async def login(req: LoginRequest):
+    """Validate credentials and return a session token."""
+    valid = (
+        ADMIN_PASSWORD  # reject if password not configured
+        and secrets.compare_digest(req.username.encode(), ADMIN_USERNAME.encode())
+        and secrets.compare_digest(req.password.encode(), ADMIN_PASSWORD.encode())
+    )
+    if not valid:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    token = secrets.token_urlsafe(32)
+    expires_at = (datetime.utcnow() + timedelta(days=SESSION_DURATION_DAYS)).isoformat()
+    db.create_session(token, expires_at)
+    db.cleanup_expired_sessions()
+    return {"token": token, "expires_at": expires_at}
+
+
+@app.get("/api/auth/check")
+async def auth_check():
+    """Verify the current session is valid (middleware handles the actual check)."""
+    return {"ok": True}
+
+
+@app.post("/api/auth/logout")
+async def logout(request: Request):
+    """Invalidate the current session token."""
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.startswith("Bearer "):
+        db.delete_session(auth_header[7:])
+    return {"ok": True}
 
 
 # === Workspace Endpoints ===

--- a/orchestrator/dashboard.py
+++ b/orchestrator/dashboard.py
@@ -97,11 +97,9 @@ async def index():
 @app.post("/api/auth/login")
 async def login(req: LoginRequest):
     """Validate credentials and return a session token."""
-    valid = (
-        ADMIN_PASSWORD  # reject if password not configured
-        and secrets.compare_digest(req.username.encode(), ADMIN_USERNAME.encode())
-        and secrets.compare_digest(req.password.encode(), ADMIN_PASSWORD.encode())
-    )
+    u_ok = secrets.compare_digest(req.username.encode(), ADMIN_USERNAME.encode())
+    p_ok = secrets.compare_digest(req.password.encode(), ADMIN_PASSWORD.encode())
+    valid = ADMIN_PASSWORD and u_ok and p_ok
     if not valid:
         raise HTTPException(status_code=401, detail="Invalid credentials")
     token = secrets.token_urlsafe(32)

--- a/orchestrator/db.py
+++ b/orchestrator/db.py
@@ -126,6 +126,12 @@ CREATE TABLE IF NOT EXISTS planning_events (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (session_id) REFERENCES planning_sessions(id)
 );
+
+CREATE TABLE IF NOT EXISTS sessions (
+    token TEXT PRIMARY KEY,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    expires_at TIMESTAMP NOT NULL
+);
 """
 
 
@@ -752,6 +758,39 @@ def get_planning_events(session_id: str, since_id: int = 0, limit: int = 200) ->
         (session_id, since_id, limit),
     ).fetchall()
     return [dict(r) for r in rows]
+
+
+# === Sessions ===
+
+
+def create_session(token: str, expires_at: str) -> None:
+    conn = _get_connection()
+    conn.execute(
+        "INSERT INTO sessions (token, created_at, expires_at) VALUES (?, ?, ?)",
+        (token, _now(), expires_at),
+    )
+    conn.commit()
+
+
+def get_session(token: str) -> dict | None:
+    conn = _get_connection()
+    row = conn.execute(
+        "SELECT * FROM sessions WHERE token = ? AND expires_at > ?",
+        (token, _now()),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def delete_session(token: str) -> None:
+    conn = _get_connection()
+    conn.execute("DELETE FROM sessions WHERE token = ?", (token,))
+    conn.commit()
+
+
+def cleanup_expired_sessions() -> None:
+    conn = _get_connection()
+    conn.execute("DELETE FROM sessions WHERE expires_at <= ?", (_now(),))
+    conn.commit()
 
 
 # === Metrics ===


### PR DESCRIPTION
Closes #5

## Summary

- **Backend**: Added HTTP middleware to FastAPI that protects all `/api/*` routes with session token auth. Login/logout/check endpoints added at `/api/auth/*`. Sessions stored in SQLite with 30-day expiry and cleaned up on new login. `secrets.compare_digest` used for timing-safe credential comparison.
- **Config**: Added `ADMIN_USERNAME` (default: `admin`) and `ADMIN_PASSWORD` (required) env vars with validation warning in `validate_environment()` and display in `print_config()`.
- **Database**: Added `sessions` table with `create_session`, `get_session`, `delete_session`, `cleanup_expired_sessions` functions.
- **Frontend**: API client injects `Authorization: Bearer <token>` header and dispatches `swarm:unauthorized` event on 401. New `AuthContext` manages token state. `LoginPage` shows a styled dark-theme login form. `App.jsx` gates rendering behind auth check. `Header.jsx` adds a logout button with `LogOut` icon.

## Test plan

- [ ] Set `ADMIN_PASSWORD=testpassword123` in `.env`, restart server — `print_config` shows `(set)`
- [ ] `curl http://localhost:8420/api/metrics` returns 401 without token
- [ ] `curl -X POST .../api/auth/login -d '{"username":"admin","password":"testpassword123"}'` returns `{"token":"...","expires_at":"..."}`
- [ ] Authenticated request with `Authorization: Bearer <token>` returns metrics JSON
- [ ] Browser shows login page when unauthenticated; redirects to dashboard after login
- [ ] Token persists across page reloads; dashboard loads without re-login
- [ ] Server restart: existing localStorage token still valid (sessions in SQLite)
- [ ] Logout button in header clears token and shows login page
- [ ] Wrong password shows "Invalid username or password" error
- [ ] Static assets (JS/CSS) load without auth token